### PR TITLE
add NVL2 oracle function

### DIFF
--- a/lib/ZeDoctrineExtensions/Query/Oracle/Nvl2.php
+++ b/lib/ZeDoctrineExtensions/Query/Oracle/Nvl2.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * ZeDoctrineExtensions Oracle Function Pack
+ * 
+ * PHP version 5
+ *
+ * LICENSE:
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ */
+
+namespace ZeDoctrineExtensions\Query\Oracle;
+
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+
+/**
+ * Nvl2(expr1, expr2, expr3)
+ *
+ * NVL2 lets you determine the value returned by a query based on whether a specified
+ * expression is null or not null. If expr1 is not null, then NVL2 returns expr2.
+ * If expr1 is null, then NVL2 returns expr3.
+ * More info:
+ * http://docs.oracle.com/database/121/SQLRF/functions132.htm#SQLRF00685
+ *
+ * @category    ZeDoctrineExtensions
+ * @package     ZeDoctrineExtensions\Query\Oracle
+ * @license     http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @author      Ala' M. Mohammad <amohammad@birzeit.edu>
+ */
+
+class Nvl2 extends FunctionNode
+{
+    private $expr1;
+    private $expr2;
+    private $expr3;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
+    {
+        return sprintf(
+            'NVL2(%s, %s, %s)',
+            $sqlWalker->walkArithmeticPrimary($this->expr1),
+            $sqlWalker->walkArithmeticPrimary($this->expr2),
+            $sqlWalker->walkArithmeticPrimary($this->expr3)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function parse(\Doctrine\ORM\Query\Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->expr1 = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->expr2 = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->expr3 = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}


### PR DESCRIPTION
NVL2 lets you determine the value returned by a query based on whether a specified expression is null or not null. If expr1 is not null, then NVL2 returns expr2. If expr1 is null, then NVL2 returns expr3.
More info: http://docs.oracle.com/database/121/SQLRF/functions132.htm#SQLRF00685
